### PR TITLE
Please remove hostname command option "-s"

### DIFF
--- a/lib/fluent/plugin/in_dstat.rb
+++ b/lib/fluent/plugin/in_dstat.rb
@@ -7,7 +7,7 @@ class DstatInput < Input
   def initialize
     super
     require 'csv'
-    @hostname = `hostname -s`.chomp!
+    @hostname = `hostname`.chomp!
     @line_number = 0
     @first_keys = []
     @second_keys = []


### PR DESCRIPTION
`hostname -s` could not get right hostname on my environments - CentOS 5.4
ex)
]# hostname -s
hostname: 不明なホスト

]# hostname
fluentd01
