### PR TITLE
replace space (e.g. memory usage) with underscore

### DIFF
--- a/lib/fluent/plugin/in_dstat.rb
+++ b/lib/fluent/plugin/in_dstat.rb
@@ -104,6 +104,8 @@ module Fluent
           @first_keys.each_with_index do |key, index|
             if key.nil? || key == ""
               @first_keys[index] = pre_key
+            else
+              @first_keys[index] = @first_keys[index].gsub(/\s/, '_')
             end
             pre_key = @first_keys[index]
           end


### PR DESCRIPTION
It is difficult to use (forwarding) terms including spaces to next fluentd.
So replace spaces with underscore like below:

```
2014-04-01 21:08:42 +1100 dstat.centos64: {"hostname":"centos64","dstat":{"memory_usage":{"used":"1968824320","free":"163844096","buff":"104062976","cach":"112762880"},"swap":{"used":"1442131968","free":"1146880"},"":{"":"1073733632"}}}
```

`memory usage` is changed to `memory_usage`.