### PR TITLE
Fix to check if /tmp/dstat.csv isn't empty

### DIFF
--- a/lib/fluent/plugin/in_dstat.rb
+++ b/lib/fluent/plugin/in_dstat.rb
@@ -156,6 +156,8 @@ module Fluent
       end
 
       def on_change(prev, cur)
+        return if cur.size < @pos
+
         buffer = @io.read(cur.size - @pos)
         @pos = cur.size
         lines = []


### PR DESCRIPTION
It occured that /tmp/dstart.csv was not re-created automatically in a certain situation.

## NG
1. Truncate /tmp/dstat.csv (echo '' > /tmp/dstat.csv), "negative length -xxxx given" error occurs,
   and /tmp/dstart.csv is created again.
2. Remove /tmp/dstat.csv, but /tmp/dstart.csv is not created again.
3. Additionally, when stopping fluentd, "No such file or directory - /tmp/dstat.csv" error occurs.

```
[root@server ~]# echo '' > /tmp/dstat.csv 

[root@server ~]# wc -l /tmp/dstat.csv 
3 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
4 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
5 /tmp/dstat.csv

[root@server ~]# rm -f /tmp/dstat.csv

[root@server ~]# wc -l /tmp/dstat.csv 
wc: /tmp/dstat.csv: No such file or directory
[root@server ~]# wc -l /tmp/dstat.csv 
wc: /tmp/dstat.csv: No such file or directory
[root@server ~]# wc -l /tmp/dstat.csv 
wc: /tmp/dstat.csv: No such file or directory
[root@server ~]# wc -l /tmp/dstat.csv 
wc: /tmp/dstat.csv: No such file or directory
:
```

### log (1)

```
2014-10-22 17:37:44 +0900 [error]: unexpected error error="negative length -3193 given"
  2014-10-22 17:37:44 +0900 [error]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-dstat-0.2.5/lib/fluent/plugin/in_dstat.rb:159:in `read'
  2014-10-22 17:37:44 +0900 [error]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-dstat-0.2.5/lib/fluent/plugin/in_dstat.rb:159:in `on_change'
  2014-10-22 17:37:44 +0900 [error]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/cool.io-1.2.4/lib/cool.io/loop.rb:88:in `run_once'
  2014-10-22 17:37:44 +0900 [error]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/cool.io-1.2.4/lib/cool.io/loop.rb:88:in `run'
  2014-10-22 17:37:44 +0900 [error]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-dstat-0.2.5/lib/fluent/plugin/in_dstat.rb:64:in `run'
```

### log (2)

```
2014-10-22 17:41:13 +0900 [info]: shutting down fluentd
2014-10-22 17:41:13 +0900 [warn]: unexpected error while shutting down plugin=Fluent::DstatInput plugin_id="object:3ffcafd0479c" error_class=Errno::ENOENT error=#<Errno::ENOENT: No such file or directory - /tmp/dstat.csv>
  2014-10-22 17:41:13 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-dstat-0.2.5/lib/fluent/plugin/in_dstat.rb:59:in `delete'
  2014-10-22 17:41:13 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-dstat-0.2.5/lib/fluent/plugin/in_dstat.rb:59:in `shutdown'
  2014-10-22 17:41:13 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.52/lib/fluent/engine.rb:277:in `block (2 levels) in shutdown'
2014-10-22 17:41:14 +0900 [info]: process finished code=0
```

## OK

### [ OK (1) ]
1. Remove /tmp/dstat.csv, and /tmp/dstart.csv is created again.

```
[root@server ~]# wc -l /tmp/dstat.csv 
9 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
10 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
11 /tmp/dstat.csv

[root@server ~]# rm -f /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
wc: /tmp/dstat.csv: No such file or directory

[root@server ~]# wc -l /tmp/dstat.csv 
8 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
9 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
```

### [ OK (2) ]
1. Truncate /tmp/dstat.csv, "negative length -xxxx given" error occurs,
   and /tmp/dstart.csv is created again.

```
[root@server ~]# wc -l /tmp/dstat.csv 
14 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
15 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
16 /tmp/dstat.csv

[root@server ~]# echo '' > /tmp/dstat.csv 

[root@server ~]# wc -l /tmp/dstat.csv 
3 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
4 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
5 /tmp/dstat.csv
```

### [ OK (3) ]
1. Remove /tmp/dstat.csv, and /tmp/dstart.csv is created again.
2. Truncate /tmp/dstat.csv, "negative length -xxxx given" error occurs,
   and /tmp/dstart.csv is created again.

```
[root@server ~]# wc -l /tmp/dstat.csv 
9 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
10 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
11 /tmp/dstat.csv

[root@server ~]# rm -f /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
wc: /tmp/dstat.csv: No such file or directory

[root@server ~]# wc -l /tmp/dstat.csv 
8 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
9 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
10 /tmp/dstat.csv

[root@server ~]# echo '' > /tmp/dstat.csv 

[root@server ~]# wc -l /tmp/dstat.csv 
3 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
4 /tmp/dstat.csv
[root@server ~]# wc -l /tmp/dstat.csv 
5 /tmp/dstat.csv
```