### PR TITLE
Add the rescue of unexpected death in restart

### DIFF
--- a/lib/fluent/plugin/in_dstat.rb
+++ b/lib/fluent/plugin/in_dstat.rb
@@ -70,7 +70,12 @@ module Fluent
 
     def restart
       Process.detach(@pid)
-      Process.kill(:TERM, @pid)
+      begin
+        Process.kill(:TERM, @pid)
+      rescue Errno::ESRCH => e
+        $log.error "unexpected death of a child process", :error=>e.to_s
+        $log.error_backtrace
+      end
       @dw.detach
       @tw.detach
       @line_number = 0


### PR DESCRIPTION
I added the exception handling when this plugin kill a child process.

If dstat process has been killed in external causes fail to restart the process by exception. And, repeat the following error:

```
2016-01-04 18:58:50 +0900 [error]: No such process
  2016-01-04 18:58:50 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-dstat-0.2.5/lib/fluent/plugin/in_dstat.rb:73:in `kill'
  2016-01-04 18:58:50 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-dstat-0.2.5/lib/fluent/plugin/in_dstat.rb:73:in `restart'
  2016-01-04 18:58:50 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-dstat-0.2.5/lib/fluent/plugin/in_dstat.rb:37:in `check_dstat'
  2016-01-04 18:58:50 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-dstat-0.2.5/lib/fluent/plugin/in_dstat.rb:176:in `call'
  2016-01-04 18:58:50 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-dstat-0.2.5/lib/fluent/plugin/in_dstat.rb:176:in `on_timer'
  2016-01-04 18:58:50 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/cool.io-1.3.0/lib/cool.io/loop.rb:88:in `run_once'
  2016-01-04 18:58:50 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/cool.io-1.3.0/lib/cool.io/loop.rb:88:in `run'
  2016-01-04 18:58:50 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-dstat-0.2.5/lib/fluent/plugin/in_dstat.rb:64:in `run'
2016-01-04 18:58:51 +0900 [error]: No such process
  2016-01-04 18:58:51 +0900 [error]: suppressed same stacktrace
2016-01-04 18:58:52 +0900 [error]: No such process
  2016-01-04 18:58:52 +0900 [error]: suppressed same stacktrace
2016-01-04 18:58:53 +0900 [error]: No such process
  2016-01-04 18:58:53 +0900 [error]: suppressed same stacktrace
2016-01-04 18:58:54 +0900 [error]: No such process
  2016-01-04 18:58:54 +0900 [error]: suppressed same stacktrace
2016-01-04 18:58:55 +0900 [error]: No such process
  2016-01-04 18:58:55 +0900 [error]: suppressed same stacktrace
...
```