### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/fluent-plugin-dstat.gemspec
+++ b/fluent-plugin-dstat.gemspec
@@ -39,16 +39,19 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<rdoc>, [">= 0"])
       s.add_development_dependency(%q<test-unit>, [">= 3.0.0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0"])
+      s.add_development_dependency(%q<rake>, ["~> 12.0"])
     else
       s.add_runtime_dependency(%q<fluentd>, [">= 0.10.7", "< 2"])
       s.add_runtime_dependency(%q<rdoc>, [">= 0"])
       s.add_dependency(%q<test-unit>, [">= 3.0.0"])
       s.add_dependency(%q<bundler>, ["~> 1.0"])
+      s.add_dependency(%q<rake>, ["~> 12.0"])
     end
   else
     s.add_runtime_dependency(%q<fluentd>, [">= 0.10.7", "< 2"])
     s.add_runtime_dependency(%q<rdoc>, [">= 0"])
     s.add_dependency(%q<test-unit>, [">= 3.0.0"])
     s.add_dependency(%q<bundler>, ["~> 1.0"])
+    s.add_dependency(%q<rake>, ["~> 12.0"])
   end
 end

--- a/lib/fluent/plugin/in_dstat.rb
+++ b/lib/fluent/plugin/in_dstat.rb
@@ -1,9 +1,9 @@
-require 'fluent/input'
+require 'fluent/plugin/input'
 
-module Fluent
+module Fluent::Plugin
   class DstatInput < Input
 
-    Plugin.register_input('dstat', self)
+    Fluent::Plugin.register_input('dstat', self)
 
     def initialize
       super
@@ -148,7 +148,7 @@ module Fluent
             'hostname' => @hostname,
             'dstat' => data
           }
-          router.emit(@tag, Engine.now, record)
+          router.emit(@tag, Fluent::Engine.now, record)
         end
         @line_number += 1
         @last_time = Time.now

--- a/lib/fluent/plugin/in_dstat.rb
+++ b/lib/fluent/plugin/in_dstat.rb
@@ -168,19 +168,5 @@ module Fluent::Plugin
         # will be readable on next event
       end
     end
-
-    class TimerWatcher < Cool.io::TimerWatcher
-      def initialize(interval, repeat, &check_dstat)
-        @check_dstat = check_dstat
-        super(interval, repeat)
-      end
-
-      def on_timer
-        @check_dstat.call
-      rescue
-        log.error $!.to_s
-        log.error_backtrace
-      end
-    end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,6 +13,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'fluent/test'
+require 'fluent/test/driver/input'
 require 'fluent/plugin/in_dstat'
 
 class Test::Unit::TestCase

--- a/test/plugin/test_in_dstat.rb
+++ b/test/plugin/test_in_dstat.rb
@@ -20,7 +20,7 @@ class DstatInputTest < Test::Unit::TestCase
   ]
 
   def create_driver(conf=CONFIG)
-    Fluent::Test::InputTestDriver.new(Fluent::DstatInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::DstatInput).configure(conf)
   end
 
   def test_configure
@@ -44,19 +44,17 @@ class DstatInputTest < Test::Unit::TestCase
   def emit_with_conf(conf)
     d = create_driver(conf)
 
-    d.run do
-      sleep 2
-    end
+    d.run(expect_emits: 1)
 
     length = `dstat #{d.instance.option} #{d.instance.delay} 1`.split("\n")[0].split("\s").length
     puts `dstat #{d.instance.option} #{d.instance.delay} 3`
 
-    emits = d.emits
-    assert_equal true, emits.length > 0
-    assert_equal length, emits[0][2]['dstat'].length
+    events = d.events
+    assert_equal true, events.length > 0
+    assert_equal length, events[0][2]['dstat'].length
 
     puts "--- #{d.instance.option} ---"
-    puts emits[0][2]
+    puts events[0][2]
     puts "--- end ---"
   end
 


### PR DESCRIPTION
**Warning:** This PR contains breaking changes.

In v0.14, Fluentd core developers do not recommend to rewrite tag for routing.
If you want to use tag for routing, please revert fbd364e and b83fbcf.
